### PR TITLE
Patches for https://github.com/openwebwork/webwork2/pull/1329

### DIFF
--- a/lib/FormatRenderedProblem.pm
+++ b/lib/FormatRenderedProblem.pm
@@ -297,12 +297,16 @@ sub formatRenderedProblem {
 			if (($key =~ /^hidden_input_field/) ||
 				($key =~ /^real_webwork/) ||
 				($key =~ /^internal/) ||
-				($key =~ /_VI$/)
+				($key =~ /_A{0,1}VI$/)
 			) {
 				# Interpolate values
-				$json_output->{$key} =~ s/(\$\w+)/$1/gee;
-				if ($key =~ /_VI$/) {
-					my $new_key = $key =~ s/_VI$//gr;
+				if ($key =~ /_AVI$/) {
+					map { s/(\$\w+)/$1/gee } @{$json_output->{$key}};
+				} else {
+					$json_output->{$key} =~ s/(\$\w+)/$1/gee;
+				}
+				if ( ($key =~ /_A{0,1}VI$/) || ($key =~ /_AVI$/) ) {
+					my $new_key = $key =~ s/_A{0,1}VI$//r;
 					$json_output->{$new_key} = $json_output->{$key};
 					delete $json_output->{$key};
 				}

--- a/lib/WebworkClient/json_format.pl
+++ b/lib/WebworkClient/json_format.pl
@@ -3,9 +3,12 @@
 # variable interpolation.
 
 # Most parts which need variable interpolation end in "_VI".
+# Parts ending in "_AVI" are references to anonymous arrays whose entries need variable interpolation.
 # Other parts which need variable interpolation are:
 #	hidden_input_field_*
 #	real_webwork_*
+
+# NOTE: When a variable needs to be interpolated later, the string should be in single quotes not in double quotes.
 
 $json_output = { head_part001_VI => '<!DOCTYPE html><html $COURSE_LANG_AND_DIR>' };
 
@@ -16,36 +19,42 @@ $json_output->{head_part010} = <<'ENDPROBLEMTEMPLATE';
 <link rel="shortcut icon" href="/webwork2_files/images/favicon.ico"/>
 ENDPROBLEMTEMPLATE
 
-$json_output->{head_part100_VI} = <<'ENDPROBLEMTEMPLATE';
-<!-- CSS Loads -->
-<link rel="stylesheet" type="text/css" href="/webwork2_files/js/vendor/bootstrap/css/bootstrap.css"/>
-<link rel="stylesheet" type="text/css" href="/webwork2_files/js/vendor/bootstrap/css/bootstrap-responsive.css"/>
-<link rel="stylesheet" type="text/css" href="/webwork2_files/node_modules/jquery-ui-dist/jquery-ui.min.css"/>
-<link rel="stylesheet" type="text/css" href="/webwork2_files/node_modules/@fortawesome/fontawesome-free/css/all.min.css"/>
-<link rel="stylesheet" type="text/css" href="/webwork2_files/css/knowlstyle.css"/>
-<link rel="stylesheet" type="text/css" href="/webwork2_files/js/apps/ImageView/imageview.css"/>
-<link rel="stylesheet" href="$themeDir/math4.css"/>
-<link rel="stylesheet" href="$themeDir/math4-coloring.css"/>
-<link rel="stylesheet" href="$themeDir/math4-overrides.css"/>
-ENDPROBLEMTEMPLATE
+# CSS loads - as an array of href values
+$json_output->{head_part100_AVI} = [
+	"/webwork2_files/js/vendor/bootstrap/css/bootstrap.css",
+	"/webwork2_files/js/vendor/bootstrap/css/bootstrap-responsive.css",
+	"/webwork2_files/node_modules/jquery-ui-dist/jquery-ui.min.css",
+	"/webwork2_files/node_modules/@fortawesome/fontawesome-free/css/all.min.css",
+	"/webwork2_files/css/knowlstyle.css",
+	"/webwork2_files/js/apps/ImageView/imageview.css",
+	'$themeDir/math4.css',
+	'$themeDir/math4-coloring.css',
+	'$themeDir/math4-overrides.css',
+];
 
-$json_ouput{head_part200_VI} = <<'ENDPROBLEMTEMPLATE';
-<!-- JS Loads -->
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6" defer></script>
-<script type="text/javascript" src="/webwork2_files/js/apps/MathJaxConfig/mathjax-config.js" defer></script>
-<script type="text/javascript" src="/webwork2_files/mathjax/es5/tex-chtml.js" id="MathJax-script" defer></script>
-<script type="text/javascript" src="/webwork2_files/node_modules/jquery/dist/jquery.min.js"></script>
-<script type="text/javascript" src="/webwork2_files/node_modules/jquery-ui-dist/jquery-ui.min.js"></script>
-<script type="text/javascript" src="/webwork2_files/js/vendor/bootstrap/js/bootstrap.js"></script>
-<script type="text/javascript" src="/webwork2_files/js/apps/InputColor/color.js"></script>
-<script type="text/javascript" src="/webwork2_files/js/apps/Base64/Base64.js"></script>
-<script type="text/javascript" src="/webwork2_files/js/vendor/underscore/underscore.js"></script>
-<script type="text/javascript" src="/webwork2_files/js/legacy/vendor/knowl.js"></script>
-<script type="text/javascript" src="/webwork2_files/js/apps/Problem/problem.js"></script>
-<script type="text/javascript" src="/webwork2_files/js/apps/ImageView/imageview.js"></script>
-<script type="text/javascript" src="/webwork2_files/node_modules/iframe-resizer/js/iframeResizer.contentWindow.min.js"></script>
-<script src="$themeDir/math4/math4.js" defer></script>
-ENDPROBLEMTEMPLATE
+# JS loads - as an array of href values - the ones which need defer are in head_part201_AVI
+$json_output->{head_part200_AVI} = [
+	"/webwork2_files/node_modules/jquery/dist/jquery.min.js",
+	"/webwork2_files/node_modules/jquery-ui-dist/jquery-ui.min.js",
+	"/webwork2_files/js/vendor/bootstrap/js/bootstrap.js",
+	"/webwork2_files/js/apps/InputColor/color.js",
+	"/webwork2_files/js/apps/Base64/Base64.js",
+	"/webwork2_files/js/vendor/underscore/underscore.js",
+	"/webwork2_files/js/legacy/vendor/knowl.js",
+	"/webwork2_files/js/apps/Problem/problem.js",
+	"/webwork2_files/js/apps/ImageView/imageview.js",
+	"/webwork2_files/node_modules/iframe-resizer/js/iframeResizer.contentWindow.min.js",
+];
+
+# JS loads - as an array of href values - the ones which need defer are in head_part201_AVI
+#     mathjax/es5/tex-chtml.js also needs id="MathJax-script" in the <script> tag
+
+$json_output->{head_part201_AVI} = [
+        "https://polyfill.io/v3/polyfill.min.js?features=es6",
+        "/webwork2_files/js/apps/MathJaxConfig/mathjax-config.js",
+        "/webwork2_files/mathjax/es5/tex-chtml.js",
+        '$themeDir/math4/math4.js',
+];
 
 $json_output->{head_part300_VI} = '$problemHeadText';
 


### PR DESCRIPTION
Modify `json_format.pl` so that the CSS and JS loads are provided as an array of URLs to be used in `href`, rather than sending the full HTML code to load them. The JS loads which need the `defer` attribute were split from `head_part200` into `head_part201`, and one of those loads `/webwork2_files/mathjax/es5/tex-chtml.js` should also get `id="MathJax-script"` in the `<script>` tag.

The creation of suitable HTML code, including the addition of the `defer` and `id` attributes where needed should be done on the side processing the JSON data.

Fixed the lines using `$themeDir` to be in single quotes so the variable interpolation will be done properly later on, when that variable is available.