### PR TITLE
Fix UTF-8 issue in SetMaker.pm

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
@@ -501,7 +501,7 @@ sub browse_local_panel {
 				{ for => 'library_sets', class => 'col-form-label-sm' },
 				$r->maketext(
 					"[_1] Problems:",
-					$lib eq '' ? $r->maketext('Local') : Encode::decode("UTF-8", $problib{$lib})
+					$lib eq '' ? $r->maketext('Local') : $problib{$lib}
 				)
 			),
 			CGI::popup_menu({
@@ -1155,7 +1155,7 @@ sub make_top_row {
 	foreach my $lib (sort(keys(%problib))) {
 		$libs .= CGI::submit({
 			name  => "browse_$lib",
-			value => Encode::decode("UTF-8", $problib{$lib}),
+			value => $problib{$lib},
 			class => 'btn btn-secondary btn-sm ms-2 mb-2',
 			($browse_which eq "browse_$lib") ? (disabled => undef) : ()
 		})


### PR DESCRIPTION
Patch for https://github.com/openwebwork/webwork2/pull/1831

To trigger the bug before the extra patch:
  1. Create a `Technion` subdirectory in `templates`
  2. Add a line to `course.conf`
```
$courseFiles{problibs}->{Technion} = "טכניון";
```


Then try to access the library browser. If gives a fatal error
```
Wide character at /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm line 1158.
```

Such a setting with a UTF-8 "name" for the library being added did not work in WeBWorK 2.17 either.
I never tried using such a setting before until until I found the `Encode::decode` when looking at https://github.com/openwebwork/webwork2/pull/1831