### PR TITLE
Use a Hebrew work for Problem in \qformat in the XeLaTeX-Hebrew hardcopyThemes

### DIFF
--- a/conf/snippets/hardcopyThemes/XeLaTeX-Hebrew-oneColumn/hardcopyPreamble.tex
+++ b/conf/snippets/hardcopyThemes/XeLaTeX-Hebrew-oneColumn/hardcopyPreamble.tex
@@ -38,7 +38,7 @@
 \renewcommand{\questionshook}{\leftmargin=0pt\labelwidth=-\labelsep}
 
 \makeatletter
-\qformat{{\bf Problem \thequestiontitle.} \if@placepoints{\bf\footnotesize(\thepoints)}\fi \hfill}
+\qformat{{\bf שאלה \thequestiontitle.} \if@placepoints{\textenglish{\bf\footnotesize(\thepoints)}}\fi \hfill}
 \makeatother
 
 \input{CAPA.tex}

--- a/conf/snippets/hardcopyThemes/XeLaTeX-Hebrew-twoColumn/hardcopyPreamble.tex
+++ b/conf/snippets/hardcopyThemes/XeLaTeX-Hebrew-twoColumn/hardcopyPreamble.tex
@@ -38,7 +38,7 @@
 \renewcommand{\questionshook}{\leftmargin=0pt\labelwidth=-\labelsep}
 
 \makeatletter
-\qformat{{\bf Problem \thequestiontitle.} \if@placepoints{\bf\footnotesize(\thepoints)}\fi \hfill}
+\qformat{{\bf שאלה \thequestiontitle.} \if@placepoints{\textenglish{\bf\footnotesize(\thepoints)}}\fi \hfill}
 \makeatother
 
 \input{CAPA.tex}


### PR DESCRIPTION
Use a Hebrew work for Problem in \qformat in the XeLaTeX-Hebrew hardcopyThemes.
Also force the point message into LTR mode, as it is in English and otherwise gets mangled.