### PR TITLE
Updates to Grades, Stats, Student Progress, and LTIUpdate Help.

### DIFF
--- a/templates/ContentGenerator/Grades/student_stats.html.ep
+++ b/templates/ContentGenerator/Grades/student_stats.html.ep
@@ -8,7 +8,19 @@
 			<th rowspan="2" scope="col"><%= maketext('Percent') %></th>
 			<th rowspan="2" scope="col"><%= maketext('Score') %></th>
 			<th rowspan="2" scope="col"><%= maketext('Out Of') %></th>
-			<th colspan="<%= $max_problems %>" scope="col"><%= maketext('Problems') %></th>
+			<th colspan="<%= $max_problems %>" scope="col">
+				<%= maketext('Problems') %>
+				<a class="help-popup" role="button" tabindex="0" data-bs-placement="top"
+					data-bs-toggle="popover"
+					data-bs-content="<%= maketext(
+						'The top number is the percent score on the problem.  A period (.) indicates a problem '
+						. 'has not been attempted. The bottom number is the number of incorrect attempts.'
+					) =%>">
+					<i class="icon fas fa-question-circle" data-alt="<%= maketext('Help Icon') =%>"
+						aria-hidden="true">
+					</i>
+				</a>
+			</th>
 		</tr>
 		<tr>
 			% for (1 .. $max_problems) {

--- a/templates/ContentGenerator/Instructor/StudentProgress/set_progress.html.ep
+++ b/templates/ContentGenerator/Instructor/StudentProgress/set_progress.html.ep
@@ -66,14 +66,6 @@
 %
 % # Table description. Only show the problem description if the problems column is shown.
 <div>
-	% if (!$setIsVersioned || $showColumns->{problems}) {
-		<p>
-			<%= maketext(
-				'A period (.) indicates a problem has not been attempted, and a number from 0 to 100 indicates '
-					. 'the grade earned. The number on the second line gives the number of incorrect attempts.'
-			) =%>
-		</p>
-	% }
 	% if ($setIsVersioned) {
 		<p>
 			<%= maketext(
@@ -165,7 +157,19 @@
 					<th <%== $rowspan %>><%= maketext('Time Remaining') %></th>
 				% }
 				% if ($showColumns->{problems}) {
-					<th colspan="<%= scalar(@$problems) %>"><%= maketext('Problems') %></th>
+					<th colspan="<%= scalar(@$problems) %>">
+						<%= maketext('Problems') =%>
+						<a class="help-popup" role="button" tabindex="0" data-bs-placement="top"
+							data-bs-toggle="popover"
+							data-bs-content="<%= maketext(
+								'The top number is the percent score on the problem.  A period (.) indicates a problem '
+								. 'has not been attempted. The bottom number is the number of incorrect attempts.'
+							) =%>">
+							<i class="icon fas fa-question-circle" data-alt="<%= maketext('Help Icon') =%>"
+								aria-hidden="true">
+							</i>
+						</a>
+					</th>
 				% }
 				% if ($showColumns->{section}) {
 					<th <%== $rowspan %>>

--- a/templates/HelpFiles/Grades.html.ep
+++ b/templates/HelpFiles/Grades.html.ep
@@ -16,8 +16,24 @@
 % layout 'help_macro';
 % title maketext('Grades Help');
 %
-<!--
-FIXME: This needs work. The prior contents of this file were clearly obsolete. When updating this remember that these
-help contents are not shown for students.
--->
-<p class="m-0"><%= maketext('Students may view their grades on this page.') %></p>
+<p>
+	<%= maketext(q{This page shows the student's current grades for all sets they are assigned to.  Only visible sets }
+		. 'are shown to the student, while invisible set names are italic when viewed as an instructor.  Students can '
+		. 'only see the per problem grades on open assignments.') =%>
+</p>
+<p>
+	<%= maketext('The total grade row at the bottom shows the total score and percent average over all open '
+		. 'assignments.  The total grade row can be shown/hidden under general course configuration settings.') =%>
+</p>
+<p class="m-0">
+	<%== maketext(
+		'Additional (external) grades can be shown on this page by placing them in the CSV file [_1].  The first six '
+			. 'columns must be (in order): Student ID, Username, Last Name, First Name, Section, Recitation.  The '
+			. 'remaining columns can list any external grades.  To display the grades, the CSV file is merged with '
+			. 'the "Email" message [_2], which will be rendered and displayed below the grade table.  The message can '
+			. 'be created on the "Email" page and the CSV file can be created/uploaded using the "File Manager".  '
+			. 'External grades can only be displayed here and are not included in any totals or statistics.',
+		'<code>[Scoring]/report_grades_data.csv</code>',
+		'<code>[TMPL]/email/report_grades.msg</code>',
+	) =%>
+</p>

--- a/templates/HelpFiles/InstructorLTIUpdate.html.ep
+++ b/templates/HelpFiles/InstructorLTIUpdate.html.ep
@@ -18,5 +18,7 @@
 %
 <p class="m-0">
 	<%= maketext('This page gives information about mass LTI grade updates, and allows you to trigger a grade update '
-		. 'for all users and all sets, all sets for one user, all users for one set, or one user for one set.') =%>
+		. 'for all users and all sets, all sets for one user, all users for one set, or one user for one set.  When '
+		. 'a user is selected, the sets drop down menu is updated to only allow selecting sets assigned the selected '
+		. 'user.  Similarly when a set is selected, the user menu is updated to only allow selecting valid users.) =%>
 </p>

--- a/templates/HelpFiles/InstructorStats.html.ep
+++ b/templates/HelpFiles/InstructorStats.html.ep
@@ -17,6 +17,13 @@
 % title maketext('Statistics Help');
 %
 <p>
-	<%= maketext('This page is a useful tool for instructors who want to see how their students are doing. Statistics '
-		. 'can either be viewed for a single set or for a single user simply by clicking on the link.') =%>
+	<%= maketext('The main page allows access to set and student statistics.  When selecting a student, their grades '
+		. 'page is shown, which lists set totals and per problem grades for each set assigned to the student.  When '
+		. 'selecting a set, various statistics and histograms are shown for the overall grades of students who are '
+		. 'currently enrolled or auditing the course.') =%>
+</p>
+<p class="mb-0">
+	<%= maketext('When viewing set statistics, the drop down menus can be used to show stats for individual sections, '
+		. 'recitations, or problems.  The overall results include all students who are assigned to the set, while the '
+		. 'individual problem results only include active (have attempted the problem) students.') =%>
 </p>

--- a/templates/HelpFiles/InstructorStudentProgress.html.ep
+++ b/templates/HelpFiles/InstructorStudentProgress.html.ep
@@ -18,13 +18,16 @@
 %
 <p>
 	<%= maketext('This page is useful for monitoring student progress on assignments. Student progress '
-		. 'can either be viewed for a single set or for a single user.') =%>
+		. 'can either be viewed for a single set or for a single student.') =%>
 </p>
 <p>
 	<%= maketext('When viewing student progress for a set, the score for the set and the status for problems in the '
-		. 'set are listed for all users.') =%>
+		. 'set are listed for all students.  The table can be sorted by clicking the links in the table header.  '
+		. q{Click the student's name to access the student's set.  When viewing progress for a test, additional }
+		. 'columns can be shown/hidden by updating the display at the top') =%>
 </p>
 <p class="mb-0">
-	<%= maketext('The progress for a single user is the same as the statistics for that user, and is also '
-		. 'essentially what is shown for the user if that user views the "Grades" page.') =%>
+	<%= maketext('When viewing progress for a single student, their grades page is shown which lists set totals and '
+		. 'per problem grades for each set assigned to the student.  This shows the same information as the '
+		. 'statistics page for the student.') =%>
 </p>


### PR DESCRIPTION
  Besides updating the instructor help files, this adds a help icon
  to the Problems header on the tables that show per problem grades
  to describe what the numbers mean.  The help is put there since it
  should also be visible to students when they are viewing the table.

  There was some text added to the student progress and grades pages
  pages that was essentially help that has been removed and placed
  in the instructor help file.

  Last I reduced the amount of information on the headers of the
  student progress pages to be more in line with the stats page to
  only list the set or student being viewed.