### PR TITLE
Site nav link colors

### DIFF
--- a/htdocs/themes/math4-green/_theme-overrides.scss
+++ b/htdocs/themes/math4-green/_theme-overrides.scss
@@ -1,0 +1,3 @@
+:root {
+	--ww-site-nav-link-active-background-color: #{darken($primary, 2%)};
+}

--- a/htdocs/themes/math4-green/_theme-overrides.scss
+++ b/htdocs/themes/math4-green/_theme-overrides.scss
@@ -1,3 +1,0 @@
-:root {
-	--ww-site-nav-link-active-background-color: #{lighten($primary, 50%)};
-}

--- a/htdocs/themes/math4-red/_theme-overrides.scss
+++ b/htdocs/themes/math4-red/_theme-overrides.scss
@@ -1,0 +1,4 @@
+a:not(.btn):focus {
+        outline-color: #{lighten($link-hover-color, 26%)};
+}
+

--- a/htdocs/themes/math4-yellow/_theme-overrides.scss
+++ b/htdocs/themes/math4-yellow/_theme-overrides.scss
@@ -22,5 +22,10 @@
 }
 
 a:not(.btn):focus {
-        outline-color: $link-hover-color;
+	outline-color: #{darken($link-hover-color, 1%)};
+}
+
+:root {
+	--ww-site-nav-link-active-background-color: #{$primary};
+	--ww-site-nav-link-active-color: #{color-contrast($primary)};
 }

--- a/htdocs/themes/math4-yellow/_theme-overrides.scss
+++ b/htdocs/themes/math4-yellow/_theme-overrides.scss
@@ -21,7 +21,6 @@
 	color: $link-color !important;
 }
 
-:root {
-	--ww-site-nav-link-active-background-color: #{$primary};
-	--ww-site-nav-link-active-color: #{color-contrast($primary)};
+a:not(.btn):focus {
+        outline-color: $link-hover-color;
 }

--- a/htdocs/themes/math4/bootstrap.scss
+++ b/htdocs/themes/math4/bootstrap.scss
@@ -95,7 +95,11 @@ a:not(.btn):focus {
 	color: $link-hover-color;
 	outline-style: solid;
 	outline-color: #{lighten($link-hover-color, 8%)};
-	outline-width: 3px;
+	outline-width: 1px;
+}
+
+#site-links a:not(.btn):focus {
+	outline-width: 2px;
 }
 
 @import "theme-overrides";

--- a/htdocs/themes/math4/bootstrap.scss
+++ b/htdocs/themes/math4/bootstrap.scss
@@ -94,7 +94,7 @@ $breadcrumb-active-color: #495057;
 a:not(.btn):focus {
 	color: $link-hover-color;
 	outline-style: solid;
-	outline-color: #{lighten($link-hover-color, 30%)};
+	outline-color: #{lighten($link-hover-color, 8%)};
 	outline-width: 3px;
 }
 

--- a/htdocs/themes/math4/bootstrap.scss
+++ b/htdocs/themes/math4/bootstrap.scss
@@ -87,16 +87,15 @@ $breadcrumb-active-color: #495057;
 	--ww-logo-background-color: #{$ww-logo-background-color};
 	--ww-primary-foreground-color: #{color-contrast($primary)};
 	--ww-achievement-level-color: #{$ww-achievement-level-color};
-	--ww-site-nav-link-active-background-color: #{lighten($primary, 55%)};
-	--ww-site-nav-link-active-color: #{$primary};
+	--ww-site-nav-link-active-background-color: #{$primary};
 }
 
 // Overrides
 a:not(.btn):focus {
 	color: $link-hover-color;
 	outline-style: solid;
-	outline-color: $link-hover-color;
-	outline-width: 1px;
+	outline-color: #{lighten($link-hover-color, 30%)};
+	outline-width: 3px;
 }
 
 @import "theme-overrides";

--- a/htdocs/themes/math4/math4.scss
+++ b/htdocs/themes/math4/math4.scss
@@ -171,7 +171,7 @@ $site-nav-width: 250px !default;
 	transition-property: left, border-right-width;
 	transition-duration: 0.3s;
 	border-right: 1px solid $layout-divider-color;
-	padding: 3px;
+	padding: 2px;
 
 	&.toggle-width {
 		left: -20%;

--- a/htdocs/themes/math4/math4.scss
+++ b/htdocs/themes/math4/math4.scss
@@ -240,6 +240,11 @@ $site-nav-width: 250px !default;
 			padding-right: 0.5rem;
 		}
 	}
+
+	hr.site-nav-separator {
+		margin: 3pt 7pt;
+		border: 1pt solid;
+	}
 }
 
 #content {
@@ -301,11 +306,6 @@ $site-nav-width: 250px !default;
 	&:focus #toggle-sidebar-icon i {
 		outline: 1px solid var(--bs-link-hover-color);
 	}
-}
-
-hr.hr {
-	margin: 3pt 7pt;
-	border: 1pt solid;
 }
 
 /* Progress Bar */

--- a/htdocs/themes/math4/math4.scss
+++ b/htdocs/themes/math4/math4.scss
@@ -171,6 +171,7 @@ $site-nav-width: 250px !default;
 	transition-property: left, border-right-width;
 	transition-duration: 0.3s;
 	border-right: 1px solid $layout-divider-color;
+	padding: 3px;
 
 	&.toggle-width {
 		left: -20%;
@@ -214,7 +215,8 @@ $site-nav-width: 250px !default;
 
 				&.active {
 					background-color: var(--ww-site-nav-link-active-background-color, #038);
-					color: var(--ww-site-nav-link-active-color, white);
+					color: var(--ww-primary-foreground-color, white);
+
 				}
 			}
 			&.list-group-item {

--- a/htdocs/themes/math4/math4.scss
+++ b/htdocs/themes/math4/math4.scss
@@ -301,6 +301,11 @@ $site-nav-width: 250px !default;
 	}
 }
 
+hr.hr {
+	margin: 3pt 7pt;
+	border: 1pt solid;
+}
+
 /* Progress Bar */
 div {
 	&.progress {

--- a/templates/ContentGenerator/Base/admin_links.html.ep
+++ b/templates/ContentGenerator/Base/admin_links.html.ep
@@ -1,6 +1,6 @@
 <ul class="nav flex-column">
 	<li class="list-group-item nav-item"><%= $makelink->('options') %></li>
-	<hr class="hr"/>
+	<hr class="site-nav-separator"/>
 	% if ($authz->hasPermissions($userID, 'create_and_delete_courses')) {
 		<li class="list-group-item nav-item">
 			<%= $makelink->(

--- a/templates/ContentGenerator/Base/admin_links.html.ep
+++ b/templates/ContentGenerator/Base/admin_links.html.ep
@@ -1,5 +1,6 @@
 <ul class="nav flex-column">
-	<li class="list-group-item list-group-item-primary nav-item"><%= $makelink->('options') %></li>
+	<li class="list-group-item nav-item"><%= $makelink->('options') %></li>
+	<hr class="hr"/>
 	% if ($authz->hasPermissions($userID, 'create_and_delete_courses')) {
 		<li class="list-group-item nav-item">
 			<%= $makelink->(

--- a/templates/ContentGenerator/Base/links.html.ep
+++ b/templates/ContentGenerator/Base/links.html.ep
@@ -86,7 +86,7 @@
 		% }
 		%
 		% if ($authz->hasPermissions($userID, 'access_instructor_tools')) {
-			<hr class="hr hr-blurry"/>
+			<hr class="site-nav-separator"/>
 			<li class="list-group-item nav-item"><%= $makelink->('instructor_tools') %></li>
 			% # Class list editor
 			<li class="list-group-item nav-item"><%= $makelink->('instructor_user_list') %></li>

--- a/templates/ContentGenerator/Base/links.html.ep
+++ b/templates/ContentGenerator/Base/links.html.ep
@@ -7,7 +7,7 @@
 <ul class="nav flex-column">
 	% if (defined $courseID && $authen->was_verified) {
 		% # Homework Sets or Course Administration
-		<li class="list-group-item list-group-item-primary nav-item">
+		<li class="list-group-item nav-item">
 			% if ($restricted_navigation) {
 				<span class="nav-link disabled"><%= maketext('Homework Sets') %></span>
 			% } else {
@@ -16,7 +16,7 @@
 		</li>
 		%
 		% if (defined $setID) {
-			<li class="list-group-item list-group-item-primary nav-item">
+			<li class="list-group-item nav-item">
 				<ul class="nav flex-column">
 					% # Set link. The set record is needed to determine the assignment type.
 					% my $setRecord = $db->getGlobalSet($setID =~ s/,v\d+$//r);
@@ -74,18 +74,19 @@
 			% || $authz->hasPermissions($userID, 'change_email_address')
 			% || $authz->hasPermissions($userID, 'change_pg_display_settings'))
 		% {
-			<li class="list-group-item list-group-item-primary nav-item"><%= $makelink->('options') %></li>
+			<li class="list-group-item nav-item"><%= $makelink->('options') %></li>
 		% }
 		%
 		% unless ($restricted_navigation || $courseID eq 'admin') {
-			<li class="list-group-item list-group-item-primary nav-item"><%= $makelink->('grades') %></li>
+			<li class="list-group-item nav-item"><%= $makelink->('grades') %></li>
 		% }
 		%
 		% if ($ce->{achievementsEnabled}) {
-			<li class="list-group-item list-group-item-primary nav-item"><%= $makelink->('achievements') %></li>
+			<li class="list-group-item nav-item"><%= $makelink->('achievements') %></li>
 		% }
 		%
 		% if ($authz->hasPermissions($userID, 'access_instructor_tools')) {
+			<hr class="hr hr-blurry"/>
 			<li class="list-group-item nav-item"><%= $makelink->('instructor_tools') %></li>
 			% # Class list editor
 			<li class="list-group-item nav-item"><%= $makelink->('instructor_user_list') %></li>


### PR DESCRIPTION
I thought I opened this last night, but I'm wondering if I never hit a final button or otherwise messed up.

Compared with develop, this:

- removes the background colors for the student nav items
- inserts an `hr` as you suggested
- increases the thickness of focus outline on a link to 3px
- to make the full outline visible on nav links, gives a 3px padding to the site nav
- tweaks the color of the link outline for the non-yellow themes

The added padding on the site nav leaves it so that the active item is visually outlined by the overall background off white. At first I did not like that, but it grew on me as I looked at more examples while tweaking things. Also it makes this more consistent with when the active link is something nested, say like a particular exercise set.
