### PR TITLE
rearrange tables in user sets page

### DIFF
--- a/templates/ContentGenerator/Instructor/UserDetail.html.ep
+++ b/templates/ContentGenerator/Instructor/UserDetail.html.ep
@@ -83,16 +83,12 @@
 	</div>
 	%
 	<div class="table-responsive">
-		<table class="table table-bordered table-sm font-sm align-middle">
+		<table class="table table-bordered table-sm font-sm align-middle w-auto caption-top">
+			<caption><%= maketext("Sets assigned to [_1] ([_2])", $userName, $userID) =%></caption>
 			<tr>
-				<th class="text-center" colspan="3">
-					<%= maketext("Sets assigned to [_1] ([_2])", $userName, $userID) =%>
-				</th>
-			</tr>
-			<tr>
+				<th class="text-center"><%= maketext('Assignment') %></th>
 				<th class="text-center"><%= maketext('Assigned') %></th>
-				<th><%= maketext("Edit set for [_1]", $userID) %></th>
-				<th><%= maketext('Dates') %></th>
+				<th class="text-center"><%= maketext('Dates') %></th>
 			</tr>
 			% for my $set (@{ $c->{setRecords} }) {
 				% my $setID = $set->set_id;

--- a/templates/ContentGenerator/Instructor/UserDetail/set_date_table.html.ep
+++ b/templates/ContentGenerator/Instructor/UserDetail/set_date_table.html.ep
@@ -5,16 +5,16 @@
 % my $isVersioned = $isGateway && defined $mergedRecord && $mergedRecord->can('version_id');
 % $setID .= ',v' . $mergedRecord->version_id if $isVersioned;
 %
-<table>
+<table <%== $isVersioned ? ' class="ms-auto"' : '' %>>
 	<tr>
-		% if (defined $userRecord) {
+		% unless ($isVersioned) {
 			<th scope="col" colspan="2">
-				<%= $isVersioned ? maketext(q{User's Test Version Dates}) : maketext('User Overrides') =%>
+				<%= maketext('Assignment Dates') =%>
 			</th>
 		% }
-		% unless ($isVersioned) {
-			<th scope="col" <%== defined $userRecord ? '' : 'colspan="2"' %>>
-				<%= $isGateway ? maketext('Test Dates') : maketext('Assignment Dates') =%>
+		% if (defined $userRecord) {
+			<th scope="col" <%== (defined $userRecord && !$isVersioned) ? '' : 'colspan="2"' %>>
+				<%= $isVersioned ? maketext(q{User's Test Version Dates}) : maketext('User Overrides') =%>
 			</th>
 		% }
 	</tr>
@@ -32,13 +32,24 @@
 						maketext($fieldLabels->{$field}),
 					class => 'form-label mb-0' =%>
 			</td>
+			% unless ($isVersioned) {
+				<td class="px-1 text-nowrap">
+					<%= text_field "set.$setID.$field.class_value" =>
+							$c->formatDateTime($globalValue, 'datetime_format_short'),
+						id => "set.$setID.$field.class_value", readonly => undef, dir => 'ltr',
+						class => 'form-control-plaintext form-control-sm w-auto',
+						size => 16,
+						defined $userRecord ? ('aria-labelledby' => "set.$setID.${field}_id") : () =%>
+				</td>
+			% }
 			% if (defined $userRecord) {
 				<td class="px-1 text-nowrap">
 					<div class="input-group input-group-sm flex-nowrap flatpickr">
 						<%= text_field "set.$setID.$field" =>
 								defined $userRecord ? $userRecord->$field : $globalValue,
 							id          => "set.$setID.${field}_id",
-							class       => 'form-control w-auto' . ($field eq 'open_date' ? ' datepicker-group' : ''),
+							class       => 'form-control w-auto'
+									. ($field eq 'open_date' ? ' datepicker-group' : ''),
 							placeholder => $isGateway
 								? ($isVersioned && $field ne 'reduced_scoring_date'
 									? maketext('Required')
@@ -58,15 +69,6 @@
 							<i class="fas fa-calendar-alt"></i>
 						</a>
 					</div>
-				</td>
-			% }
-			% unless ($isVersioned) {
-				<td class="px-1 text-nowrap">
-					<%= text_field "set.$setID.$field.class_value" =>
-							$c->formatDateTime($globalValue, 'datetime_format_short'),
-						id => "set.$setID.$field.class_value", readonly => undef, dir => 'ltr',
-						class => 'form-control form-control-sm w-auto',
-						defined $userRecord ? ('aria-labelledby' => "set.$setID.${field}_id") : () =%>
 				</td>
 			% }
 		</tr>

--- a/templates/ContentGenerator/Instructor/UserDetail/set_row.html.ep
+++ b/templates/ContentGenerator/Instructor/UserDetail/set_row.html.ep
@@ -2,29 +2,40 @@
 %
 % # my ($set, $userSet, $mergedSet, $version) = @_;
 % my $setID   = $set->set_id;
+% my $isGateway = $set->assignment_type =~ /gateway/;
 % my $version = stash 'version';
 <tr>
-	<td class="text-center">
-		<label class="form-check-label">
-			<%= check_box $version ? "set.$setID,v$version.assignment" : "set.$setID.assignment" => 'assigned',
-				class => 'form-check-input', defined $mergedSet ? (checked => undef) : () =%>
-		</label>
-	</td>
-	<td class="text-center">
+	<th class="text-center" scope="row">
 		% if (defined $mergedSet) {
-			<b dir="ltr">
+			<span dir="ltr">
+				% if ($isGateway) {
+					<i class="icon fa-solid fa-list-check" title="<%= maketext('Test/Quiz') %>"></i>
+					<span class="visually-hidden"><%= maketext('Test/Quiz') %></span>
+				% }
 				<%= link_to format_set_name_display($version ? "$setID (version $version)" : $setID) =>
 					$c->systemLink(
 						url_for('instructor_set_detail', setID => $setID . ($version ? ",v$version" : '')),
 						params => { editForUser => $userID }
 					) =%>
-			</b>
+			</span>
 			% if ($version) {
 				<%= hidden_field "set.$setID,v$version.assignment" => 'delete' =%>
 			% }
 		% } else {
-			<b dir="ltr"><%= format_set_name_display($setID) %></b>
+			<span dir="ltr">
+				% if ($isGateway) {
+					<i class="icon fa-solid fa-list-check" title="<%= maketext('Test/Quiz') %>"></i>
+					<span class="visually-hidden"><%= maketext('Test/Quiz') %></span>
+				% }
+				<%= format_set_name_display($setID) %>
+			</span>
 		% }
+	</th>
+	<td class="text-center">
+		<label class="form-check-label">
+			<%= check_box $version ? "set.$setID,v$version.assignment" : "set.$setID.assignment" => 'assigned',
+				class => 'form-check-input', defined $mergedSet ? (checked => undef) : () =%>
+		</label>
 	</td>
 	<td class="text-center">
 		<%= include 'ContentGenerator/Instructor/UserDetail/set_date_table',


### PR DESCRIPTION
I made some changes to all the tables in the user sets page.

* move set name to the first column and make it a row header
* also simplify that column's column header text to just be 'Assignment'. (It was `Edit set for [_1]` but the caption already tells you the relevant user and "Edit" is not really valid for the sets not assigned to this user.)
* move the "caption" to a true HTML caption
* make the table have `w-auto` so on a large screen it's not stretching all the way across
* for the dates, put the course values first
* style the readonly course values so they don't look editable
* reduce the readonly date input widths, but also give a `min-width: fit-content` so that as a screen narrows, they are not obscured
* put the same icon in front of quizzes that we have on the main homework sets page

Maybe some things are controversial here. I'm thinking of w-auto on the table, and rearranging the column order. I don't mind if things are rejected.